### PR TITLE
Modal does not have scrollbar

### DIFF
--- a/src/Vue2BootstrapModal.vue
+++ b/src/Vue2BootstrapModal.vue
@@ -4,11 +4,16 @@
     background: rgba(0, 0, 0, 0.3);
 }
 
+.vue-modal-open {
+    overflow-x: hidden !important;
+    overflow-y: auto !important;
+}
+
 </style>
 
 <template>
 
-<div ref="modal" class="modal fade background-darken" tabindex="-1" role="dialog" :class="{in:isOpen,show:isShow}" @click.self="close()" @keyup.esc="close()">
+<div ref="modal" class="modal fade background-darken" tabindex="-1" role="dialog" :class="{'in vue-modal-open':isOpen, show:isShow}" @click.self="close()" @keyup.esc="close()">
     <div class="modal-dialog" :class="modalSize" role="document">
         <div class="modal-content">
             <div v-if="needHeader" class="modal-header">


### PR DESCRIPTION
Hello again!

I keep experimenting with your component. I found small bug. When modal's content does not fit into the screen it does not get scrollbar.

I found out already that original JS code from bootstrap adds `modal-open` class to... `body` tag. Then `.modal-open .modal` rule gets applied to modal's `div` tag and it contains:
```
overflow-x: hidden;
overflow-y: auto;
```
I believe modifying `body` class is not the way to go :) 

Do you have any idea how to fix it in proper way?  In this MR I added custom class `vue-modal-open` with `!important` rule to override `overflow: hidden` from `.modal` but I'm not sure if it's fair enough.

Thanks for feedback!

Edit: I played with `index.html` to test it but I didn't want to commit some crap content in example.