### PR TITLE
fix: Disappear scroll bar browser

### DIFF
--- a/src/Vue2BootstrapModal.vue
+++ b/src/Vue2BootstrapModal.vue
@@ -92,6 +92,7 @@ export default {
     },
     methods: {
         open() {
+                if (this.isShow) return
                 this.isShow = true
                 this.$nextTick(function() {
                     this.isOpen = true


### PR DESCRIPTION
### Issue
Sometime, when user double click the button show modal. It make the scroll of browser disappear because modal save the previous css of body.